### PR TITLE
Fix UnicodeError in superReadCSV(...)

### DIFF
--- a/qtpandas/utils.py
+++ b/qtpandas/utils.py
@@ -71,8 +71,12 @@ def superReadCSV(filepath, first_codec='UTF_8', usecols=None,
 
         assert isinstance(first_codec, str), "first_codec must be a string"
 
-        codecs = list(set([first_codec] + ['UTF_8', 'ISO-8859-1', 'ASCII',
-                                           'UTF_16', 'UTF_32']))
+        codecs = ['UTF_8', 'ISO-8859-1', 'ASCII', 'UTF_16', 'UTF_32']
+        try:
+            codecs.remove(first_codec)
+        except ValueError as not_in_list:
+            pass
+        codecs.insert(0, first_codec)
         errors = []
         for c in codecs:
             try:
@@ -86,8 +90,10 @@ def superReadCSV(filepath, first_codec='UTF_8', usecols=None,
                                    sep=sep,
                                    chunksize=chunksize,
                                    **kwargs)
-
-            except (UnicodeDecodeError, UnboundLocalError) as e:
+            # Need to catch `UnicodeError` here, not just `UnicodeDecodeError`,
+            # because pandas 0.23.1 raises it when decoding with UTF_16 and the
+            # file is not in that format:
+            except (UnicodeError, UnboundLocalError) as e:
                 errors.append(e)
             except Exception as e:
                 errors.append(e)


### PR DESCRIPTION
The CSVImportDialog sometimes produced a `UnicodeDecodeError` when using pandas 0.23.1. There were several reasons for this:

qtpandas assumed that Python's `set(...)` maintains the item order. But that's not the case. In particular, `superReadCSV` used a set to keep track of codecs to try when reading a file. By adding the `first_codec` parameter into this set first, qtpandas assumed it would then get that element back first when iterating over the set. This was not always the case in my tests (precisely because the set order is not guaranteed). It lead to `superReadCSV` not obeying the `first_codec` parameter, and sometimes trying other codecs before the requested one.

Next, in pandas 0.23.1, `read_csv(...)` can raise a `UnicodeError`. But qtpandas was only catching `UnicodeDecodeError`. I updated the code to make qtpandas handle the more general exception.